### PR TITLE
Fix Heroku deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "clean": "bin/clean.sh",
     "build": "npm run clean && bin/build.sh",
-    "prestart": "npm run build",
+    "postinstall": "npm run build",
     "start": "node server/app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "dependencies": {
     "angular": "^1.4.9",
     "bootstrap": "^3.3.6",
+    "browserify": "^13.0.0",
     "express": "^4.13.4"
   },
   "devDependencies": {
-    "browserify": "^13.0.0",
     "clean-css": "^3.4.9",
     "node-sass": "^3.4.2",
     "nodemon": "^1.8.1",


### PR DESCRIPTION
* Use `postinstall` instead of `prestart`
* Add `browserify` as a `dependency` instead of `devDependency` as Heroku needs to install it in order to use it